### PR TITLE
Fix crash when trigger used without text

### DIFF
--- a/src/EntitiesSuggestor.ts
+++ b/src/EntitiesSuggestor.ts
@@ -76,11 +76,16 @@ export class EntitiesSuggestor extends EditorSuggest<EntitySuggestionItem> {
 			.slice(0, cursor.ch);
 
 		// Match the last occurrence of the trigger character
-		const match = currentLineToCursor.match(/(.*)([@:/])($|(?:[^\s].*?$))/);
+                const match = currentLineToCursor.match(/(.*)([@:/])($|(?:[^\s].*?$))/);
 
-		if (match && match.index !== undefined) {
-			const start = match.index + match[1].length + 1; // Correctly adjust start to include trigger character
-			const query = match[2] + match[3]; // The trigger and the captured query part after the trigger
+                if (match && match.index !== undefined) {
+                        // Ensure empty strings are respected when selecting capture groups
+                        const beforeDelimiter = match[1] ?? "";
+                        const trigger = match[2] ?? "";
+                        const afterDelimiter = match[3] ?? "";
+
+                        const start = match.index + beforeDelimiter.length + 1; // Correctly adjust start to include trigger character
+                        const query = trigger + afterDelimiter; // The trigger and the captured query part after the trigger
 
 			// Check if the query starts with the last dismissed query
 			if (

--- a/tests/EntitiesSuggestor.test.ts
+++ b/tests/EntitiesSuggestor.test.ts
@@ -164,17 +164,33 @@ describe("onTrigger tests", () => {
 		expect(result).toBeNull();
 	});
 
-	test("onTrigger should return null when @ is followed by spaces", () => {
-		mockEditor.getLine.mockImplementationOnce(() => "@   ");
-		const cursorPosition = { line: 0, ch: 4 };
-		const result = suggestor.onTrigger(
-			cursorPosition,
-			mockEditor,
-			mockFile
-		);
+        test("onTrigger should return null when @ is followed by spaces", () => {
+                mockEditor.getLine.mockImplementationOnce(() => "@   ");
+                const cursorPosition = { line: 0, ch: 4 };
+                const result = suggestor.onTrigger(
+                        cursorPosition,
+                        mockEditor,
+                        mockFile
+                );
 
-		expect(result).toBeNull();
-	});
+                expect(result).toBeNull();
+        });
+
+        test("onTrigger should handle a lone @ at the start of a line", () => {
+                mockEditor.getLine.mockImplementationOnce(() => "@");
+                const cursorPosition = { line: 0, ch: 1 };
+                const result = suggestor.onTrigger(
+                        cursorPosition,
+                        mockEditor as Editor,
+                        mockFile
+                );
+
+                expect(result).toEqual({
+                        start: { line: 0, ch: 1 },
+                        end: cursorPosition,
+                        query: "@",
+                });
+        });
 
 	test("onTrigger should return correct trigger info when @ is at the beginning of the line followed by text", () => {
 		mockEditor.getLine.mockImplementationOnce(() => "@example");


### PR DESCRIPTION
## Summary
- fix capture group handling in `onTrigger`
- add regression test for bare `@` trigger

## Testing
- `npm test`