### PR TITLE
Add custom property alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For example, perhaps you have a folder called "People". Entities allows you trig
 - Integration with Dataview for dynamic entity suggestions.
 - Template-based entity creation and insertion.
 - Customizable settings for each provider.
+- Use frontmatter properties as additional aliases when searching.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- allow FolderEntityProvider to pull alias values from a user defined property
- support same property alias behavior in DataviewEntityProvider
- expose advanced setting to pick the property
- document property alias feature in README

## Testing
- `npm test`