### PR TITLE
Fix folder parameter for templater template creation

### DIFF
--- a/src/Providers/EntityProvider.ts
+++ b/src/Providers/EntityProvider.ts
@@ -67,13 +67,13 @@ export abstract class EntityProvider<T extends EntityProviderUserSettings> {
 			icon: "plus-circle",
 			action: async () => {
 				console.log(`New ${template.entityName}: ${query}`);
-				await createNewNoteFromTemplate(
-					this.plugin,
-					template.templatePath,
-					"TODO FIX FOLDER",
-					query,
-					false
-				);
+                                await createNewNoteFromTemplate(
+                                        this.plugin,
+                                        template.templatePath,
+                                        this.plugin.app.vault.getRoot(),
+                                        query,
+                                        false
+                                );
 				await new Promise(resolve => setTimeout(resolve, 20));
 				return `[[${query}]]`;
 			},

--- a/src/Providers/MetadataMenuProvider.ts
+++ b/src/Providers/MetadataMenuProvider.ts
@@ -133,13 +133,13 @@ export class MetadataMenuProvider extends EntityProvider<MetadataMenuProviderUse
 				suggestionText: `New ${fileClassName}: ${query}`,
 				icon: icon,
 				action: async () => {
-					await createNewNoteFromTemplate(
-						this.plugin,
-						template,
-						"", // TODO THINK ABOUT FOLDER
-						query,
-						false
-					);
+                                        await createNewNoteFromTemplate(
+                                                this.plugin,
+                                                template,
+                                                this.plugin.app.vault.getRoot(),
+                                                query,
+                                                false
+                                        );
 					await new Promise((resolve) => setTimeout(resolve, 20));
 					return `[[${query}]]`;
 				},

--- a/src/Providers/TemplateProvider.ts
+++ b/src/Providers/TemplateProvider.ts
@@ -213,7 +213,7 @@ export class TemplateEntityProvider extends EntityProvider<TemplateProviderUserS
             createNewNoteFromTemplate(
                 this.plugin,
                 file,
-                "", // Assuming FOLDER_SETTING is managed elsewhere or not needed
+                this.plugin.app.vault.getRoot(),
                 NEW_TEMPLATE_NAME,
                 false // Assuming OPEN_NEW_NOTE is managed elsewhere or not needed
             );

--- a/src/entities.types.ts
+++ b/src/entities.types.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, TFile } from "obsidian";
+import { App, Plugin, TFile, TFolder } from "obsidian";
 import { EntityProviderUserSettings } from "./Providers/EntityProvider";
 
 export enum TriggerCharacter {
@@ -49,17 +49,17 @@ export interface EntitiesSettings {
 	providerSettings: EntityProviderUserSettings[];
 }
 export interface TemplaterPlugin {
-	templater?: {
-		create_new_note_from_template?: (
-			file: TFile | string,
-			folderSetting: string,
-			newTemplateName: string,
-			openNewNote: boolean
-		) => Promise<TFile | undefined>;
-		append_template_to_active_file?: (
-			template_file: TFile
-		) => Promise<void>;
-	};
+        templater?: {
+                create_new_note_from_template?: (
+                        file: TFile | string,
+                        folder: TFolder,
+                        newTemplateName: string,
+                        openNewNote: boolean
+                ) => Promise<TFile | undefined>;
+                append_template_to_active_file?: (
+                        template_file: TFile
+                ) => Promise<void>;
+        };
 }
 
 export const DEFAULT_SETTINGS: EntitiesSettings = {

--- a/src/entititiesUtilities.ts
+++ b/src/entititiesUtilities.ts
@@ -1,4 +1,4 @@
-import { TFile, Plugin } from "obsidian";
+import { TFile, Plugin, TFolder } from "obsidian";
 import { AppWithPlugins } from "src/entities.types";
 import { TemplaterPlugin } from "src/entities.types";
 
@@ -25,7 +25,13 @@ export function insertTemplateUsingTemplater(plugin: Plugin, template: TFile): P
 	}
     return templaterPlugin.templater.append_template_to_active_file(template);
 }
-export async function createNewNoteFromTemplate(plugin: Plugin, template: TFile | string, folderSetting: string, newTemplateName: string, openNewNote: boolean): Promise<TFile | undefined> {
+export async function createNewNoteFromTemplate(
+    plugin: Plugin,
+    template: TFile | string,
+    folder: TFolder | string,
+    newTemplateName: string,
+    openNewNote: boolean
+): Promise<TFile | undefined> {
     const templaterPlugin = getTemplaterPlugin(plugin);
     if (typeof template === 'string') {
         const templateFile = plugin.app.vault.getAbstractFileByPath(template);
@@ -37,9 +43,31 @@ export async function createNewNoteFromTemplate(plugin: Plugin, template: TFile 
         }
     }
 
+    let targetFolder: TFolder;
+    if (typeof folder === "string") {
+        if (folder === "") {
+            targetFolder = plugin.app.vault.getRoot();
+        } else {
+            const folderFile = plugin.app.vault.getAbstractFileByPath(folder);
+            if (folderFile instanceof TFolder) {
+                targetFolder = folderFile;
+            } else {
+                console.error(`Folder: "${folder}" not found or is not a valid TFolder.`);
+                return;
+            }
+        }
+    } else {
+        targetFolder = folder;
+    }
+
     if (!templaterPlugin || !templaterPlugin.templater?.create_new_note_from_template) {
         console.error("Templater plugin not found!");
         return;
     }
-    return templaterPlugin.templater.create_new_note_from_template(template, folderSetting, newTemplateName, openNewNote);
+    return templaterPlugin.templater.create_new_note_from_template(
+        template,
+        targetFolder,
+        newTemplateName,
+        openNewNote
+    );
 }


### PR DESCRIPTION
## Summary
- ensure `createNewNoteFromTemplate` passes a `TFolder` to Templater
- update templater type definition
- use the vault root when providers create new notes from templates

## Testing
- `npm test`
- `npm run build`
