### PR TITLE
Add optional folder setting for new notes from template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-entities",
-	"version": "0.3.5",
+	"version": "0.3.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-entities",
-			"version": "0.3.5",
+			"version": "0.3.7",
 			"license": "MIT",
 			"dependencies": {
 				"@popperjs/core": "^2.11.8",

--- a/src/Providers/EntityProvider.ts
+++ b/src/Providers/EntityProvider.ts
@@ -70,7 +70,7 @@ export abstract class EntityProvider<T extends EntityProviderUserSettings> {
 				await createNewNoteFromTemplate(
 					this.plugin,
 					template.templatePath,
-					"TODO FIX FOLDER",
+					template.folderPath || "",
 					query,
 					false
 				);

--- a/src/entities.types.ts
+++ b/src/entities.types.ts
@@ -33,6 +33,7 @@ export type entityFromTemplateSettings = {
 	engine: "disabled" | "core" | "templater";
 	templatePath: string;
 	entityName: string;
+	folderPath?: string;
 };
 
 export interface EntityFilter {

--- a/src/userComponents.ts
+++ b/src/userComponents.ts
@@ -8,7 +8,7 @@ import {
 	getIcon,
 } from "obsidian";
 import { entityFromTemplateSettings } from "./entities.types";
-import { FileSuggest } from "./ui/file-suggest";
+import { FileSuggest, FolderSuggest } from "./ui/file-suggest";
 
 
 import { Notice, setIcon } from "obsidian";
@@ -145,6 +145,7 @@ export class TemplateDetailsModal extends Modal {
 		let engineDropdown: DropdownComponent;
 		let templatePathInput: TextComponent;
 		let entityNameInput: TextComponent;
+		let folderPathInput: TextComponent;
 
 		// Engine Dropdown Setting
 		new Setting(contentEl)
@@ -161,6 +162,7 @@ export class TemplateDetailsModal extends Modal {
 					.onChange((value) => {
 						templatePathInput.setDisabled(value === "disabled");
 						entityNameInput.setDisabled(value === "disabled");
+						folderPathInput.setDisabled(value === "disabled");
 					});
 				engineDropdown = dropdown;
 			});
@@ -190,6 +192,19 @@ export class TemplateDetailsModal extends Modal {
 				text.setDisabled(engineDropdown.getValue() === "disabled");
 			});
 
+		// Folder Path Input Setting
+		new Setting(contentEl)
+			.setName("Folder for New Note")
+			.setDesc("Optional folder path where new notes will be created (leave empty for vault root)")
+			.addText((text) => {
+				text.setPlaceholder("Folder Path (optional)").setValue(
+					this.initialSettings?.folderPath || ""
+				);
+				folderPathInput = text;
+				text.setDisabled(engineDropdown.getValue() === "disabled");
+				new FolderSuggest(this.app, text.inputEl);
+			});
+
 		// Save Button
 		new Setting(contentEl)
 			.addButton((button) =>
@@ -201,6 +216,7 @@ export class TemplateDetailsModal extends Modal {
 							| "templater",
 						templatePath: templatePathInput.getValue(),
 						entityName: entityNameInput.getValue(),
+						folderPath: folderPathInput.getValue() || undefined,
 					};
 					this.close();
 					this.resolve(templateDetails);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add an optional folder path field to template settings for new notes, resolving the "TODO FIX FOLDER" issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-54b018a1-5b61-43ad-b4b2-ec3aa66260b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54b018a1-5b61-43ad-b4b2-ec3aa66260b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>