### PR TITLE
[codex] Add Obsidian CLI entity creation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,11 @@ This document explains the overall layout and flow of the **Entities** Obsidian 
 │   │   ├── file-suggest.ts              # File/folder suggesters
 │   │   ├── FrontmatterKeySuggest.ts     # Frontmatter key autocomplete
 │   │   └── providerSettingsComponents.ts # Shared settings UI builders
+│   ├── cli/            # Native Obsidian CLI handlers
+│   │   └── EntitiesCli.ts
+│   ├── entityCreation/ # Shared template-backed entity creation flow
+│   │   ├── EntityCreationService.ts
+│   │   └── EntityCreationSuggestions.ts
 │   ├── EntitiesSuggestor.ts   # EditorSuggest implementation
 │   ├── EntitiesSettings.ts    # Settings tab & modal
 │   ├── entities.types.ts      # Shared types & interfaces
@@ -45,6 +50,8 @@ This document explains the overall layout and flow of the **Entities** Obsidian 
    - Registers all provider classes.
    - Instantiates provider instances from saved settings.
    - Creates an `EntitiesSuggestor` and registers it with Obsidian.
+   - Registers native Obsidian CLI handlers when the host Obsidian version
+     exposes `registerCliHandler`.
    - On unload, cleans up pending saves and resets providers.
 
 2. **`EntitiesSuggestor`** – Implements `EditorSuggest`:
@@ -100,11 +107,36 @@ Shared UI builders eliminating duplication across provider settings:
   and optional note count.
 - `entityTemplateStatusLabel()` – Human-readable template status string.
 
+### Entity Creation (`src/entityCreation/`)
+
+Template-backed entity creation is shared between the editor suggester and the
+native Obsidian CLI:
+
+- `EntityCreationService` lists enabled provider creation targets, assigns
+  stable ids, resolves ids or unique entity names, and calls the template
+  creation utility.
+- `EntityCreationSuggestions` adapts those creation definitions into the
+  low-scored `New <Entity>: <query>` suggestion items used by the editor UI.
+
+Providers expose `EntityCreationDefinition` objects through
+`getEntityCreationDefinitions()`. This keeps provider discovery synchronous
+while ensuring UI actions and CLI commands use the same target model.
+
+### CLI (`src/cli/EntitiesCli.ts`)
+
+`registerEntitiesCli()` registers the native `entities` and `entities:create`
+commands through Obsidian's `registerCliHandler` API. The registration is
+guarded so older Obsidian versions continue to load the plugin without CLI
+support. Handlers resolve providers lazily on each invocation so settings
+changes are reflected without a plugin reload.
+
 ## Major Interfaces
 
 - **`EntityProvider<T>`** (abstract base class)
   - Holds provider settings and plugin reference.
   - Defines `getEntityList(query, trigger)` (sync) and optional template creation.
+  - Exposes `getEntityCreationDefinitions()` for template-backed creation
+    targets shared by suggestions and CLI commands.
   - Exposes `triggers` getter, `isEnabled` getter, and `getRefreshBehavior()`.
 
 - **`ProviderRegistry`** (singleton)
@@ -117,6 +149,12 @@ Shared UI builders eliminating duplication across provider settings:
   - Collects and caches suggestions per provider with configurable refresh.
   - Performs fuzzy search and deduplication.
   - Handles text insertion and provider actions.
+
+- **`EntityCreationService`**
+  - Lists creation targets from enabled providers.
+  - Resolves exact target ids and unique entity names.
+  - Creates notes through the existing template utility and returns structured
+    results for CLI formatting.
 
 - **`RegisterableEntityProvider`** – Type describing provider classes that can be
   registered. Requires static `providerTypeID`, `getDescription()`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,6 +122,12 @@ Providers expose `EntityCreationDefinition` objects through
 `getEntityCreationDefinitions()`. This keeps provider discovery synchronous
 while ensuring UI actions and CLI commands use the same target model.
 
+Creation definitions can be template-backed with `templatePath` and
+`folderPath`, or provider-backed with a custom `create()` handler. Providers can
+also attach CLI discovery metadata such as `description`, `inputLabel`, and
+`examples`; this metadata is returned by `obsidian entities format=json` so
+agents can learn the expected input format before calling `entities:create`.
+
 ### CLI (`src/cli/EntitiesCli.ts`)
 
 `registerEntitiesCli()` registers the native `entities` and `entities:create`
@@ -153,8 +159,9 @@ changes are reflected without a plugin reload.
 - **`EntityCreationService`**
   - Lists creation targets from enabled providers.
   - Resolves exact target ids and unique entity names.
-  - Creates notes through the existing template utility and returns structured
-    results for CLI formatting.
+  - Creates notes through either the existing template utility or a
+    provider-supplied creation handler.
+  - Returns structured results for CLI formatting.
 
 - **`RegisterableEntityProvider`** – Type describing provider classes that can be
   registered. Requires static `providerTypeID`, `getDescription()`,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ obsidian entities
 obsidian entities format=json
 ```
 
+Learn the available commands and flags from the CLI itself:
+
+```bash
+obsidian help entities
+obsidian help entities:create
+```
+
 Create an entity using the same template creation configuration used by the `@` suggester:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ npm run build
 
 Open **Settings → Entities** to add providers and configure their options. Start typing `@`, `:` or `/` to see the autocomplete menu.
 
+## Obsidian CLI
+
+Entities registers native Obsidian CLI commands when running in Obsidian 1.12.2 or newer.
+
+List configured entity creation targets:
+
+```bash
+obsidian entities
+obsidian entities format=json
+```
+
+Create an entity using the same template creation configuration used by the `@` suggester:
+
+```bash
+obsidian entities:create entity=person name="Ada Lovelace"
+obsidian entities:create entity=folder:person name="Ada Lovelace" open format=json
+```
+
+Use `obsidian entities` to find stable target ids. If multiple providers expose the same entity name, `entities:create` requires the id.
+
 ## Development
 
 Run tests with:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ obsidian entities
 obsidian entities format=json
 ```
 
+The JSON output includes provider-supplied discovery metadata when available:
+`description`, `inputLabel`, and `examples`. Agents should prefer
+`obsidian entities format=json` before creating notes so they can choose the
+right target id and input format.
+
 Learn the available commands and flags from the CLI itself:
 
 ```bash

--- a/src/Providers/EntityProvider.ts
+++ b/src/Providers/EntityProvider.ts
@@ -1,8 +1,11 @@
 import { EntitySuggestionItem } from "src/EntitiesSuggestor";
 import { entityFromTemplateSettings } from "../entities.types";
-import { createNewNoteFromTemplate } from "../entitiesUtilities";
-import { Plugin, SearchResult } from "obsidian";
+import type { Plugin } from "obsidian";
 import { TriggerCharacter } from "../entities.types";
+import { buildEntityCreationSuggestions } from "../entityCreation/EntityCreationSuggestions";
+import type {
+	EntityCreationDefinition,
+} from "../entityCreation/EntityCreationService";
 
 // Base interfaces and classes for Providers
 export interface EntityProviderID {
@@ -51,6 +54,18 @@ export abstract class EntityProvider<T extends EntityProviderUserSettings> {
 		return [TriggerCharacter.At]; // Default to '@' if not overridden
 	}
 
+	/** Lists template-backed entity creation definitions supported by this provider. */
+	getEntityCreationDefinitions(): EntityCreationDefinition[] {
+		return (this.settings.entityCreationTemplates ?? [])
+			.filter((template) => template.engine === "templater")
+			.map((template) => ({
+				providerTypeID: this.settings.providerTypeID,
+				entityName: template.entityName,
+				templatePath: template.templatePath,
+				folderPath: template.folderPath ?? "",
+			}));
+	}
+
 	/**
 	 * Generates suggestions for creating new notes based on templates for a given query.
 	 * Currently, only supports templates processed by the "templater" engine.
@@ -61,26 +76,10 @@ export abstract class EntityProvider<T extends EntityProviderUserSettings> {
 	 * @returns An array of suggestions for entity creation.
 	 */
 	getTemplateCreationSuggestions(query: string): EntitySuggestionItem[] {
-		if (!this.settings.entityCreationTemplates) return [];
-		// Only Templater templates are supported for now
-		const creationTemplates = this.settings.entityCreationTemplates.filter(
-			(template) => template.engine === "templater"
+		return buildEntityCreationSuggestions(
+			this.plugin,
+			this.getEntityCreationDefinitions(),
+			query
 		);
-		return creationTemplates.map((template) => ({
-			suggestionText: `New ${template.entityName}: ${query}`,
-			icon: "plus-circle",
-			action: async () => {
-				await createNewNoteFromTemplate(
-					this.plugin,
-					template.templatePath,
-					template.folderPath ?? "",
-					query,
-					false
-				);
-				await new Promise(resolve => setTimeout(resolve, 20));
-				return `[[${query}]]`;
-			},
-			match: { score: -10, matches: [] } as SearchResult,
-		}));
 	}
 }

--- a/src/Providers/MetadataMenuProvider.ts
+++ b/src/Providers/MetadataMenuProvider.ts
@@ -1,8 +1,9 @@
-import { ExtraButtonComponent, Plugin, SearchResult, Setting, TFile } from "obsidian";
+import { ExtraButtonComponent, Plugin, Setting } from "obsidian";
 import { EntitySuggestionItem } from "src/EntitiesSuggestor";
 import { EntityProvider, EntityProviderUserSettings } from "./EntityProvider";
 import { AppWithPlugins } from "src/entities.types";
-import { createNewNoteFromTemplate } from "src/entitiesUtilities";
+import { buildEntityCreationSuggestions } from "src/entityCreation/EntityCreationSuggestions";
+import type { EntityCreationDefinition } from "src/entityCreation/EntityCreationService";
 
 const newProviderTypeID = "metadata-menu";
 
@@ -36,6 +37,25 @@ const defaultNewProviderUserSettings: MetadataMenuProviderUserSettings = {
 	entityCreationTemplates: [],
 	// Add default values for additional settings here
 };
+
+function parseTemplateLinkpath(templateValue: unknown): string | undefined {
+	if (typeof templateValue !== "string") return undefined;
+
+	const trimmedValue = templateValue.trim();
+	const startsWrapped = trimmedValue.startsWith("[[");
+	const endsWrapped = trimmedValue.endsWith("]]");
+	if (startsWrapped !== endsWrapped) return undefined;
+
+	const linkpath =
+		startsWrapped && endsWrapped
+			? trimmedValue.slice(2, -2).trim()
+			: trimmedValue;
+	const pathWithoutAlias = linkpath.split("|", 1)[0]?.trim();
+
+	return pathWithoutAlias && pathWithoutAlias.length > 0
+		? pathWithoutAlias
+		: undefined;
+}
 
 export class MetadataMenuProvider extends EntityProvider<MetadataMenuProviderUserSettings> {
 	static readonly providerTypeID: string = newProviderTypeID;
@@ -82,6 +102,44 @@ export class MetadataMenuProvider extends EntityProvider<MetadataMenuProviderUse
 		return [];
 	}
 
+	/** Lists Metadata Menu file classes configured with resolvable new note templates. */
+	getEntityCreationDefinitions(): EntityCreationDefinition[] {
+		if (!this.mdmPlugin?.fieldIndex) return [];
+
+		const definitions: EntityCreationDefinition[] = [];
+		for (const [path, fileClass] of this.mdmPlugin.fieldIndex.fileClassesPath) {
+			const fileCache = this.plugin.app.metadataCache.getCache(path);
+			const frontmatter = fileCache?.frontmatter;
+			if (!frontmatter) continue;
+
+			const newNoteTemplate = Array.isArray(frontmatter.newNoteTemplate)
+				? frontmatter.newNoteTemplate[0]
+				: frontmatter.newNoteTemplate;
+			const strippedTemplateName = parseTemplateLinkpath(newNoteTemplate);
+			if (!strippedTemplateName) continue;
+
+			const templateFile = this.plugin.app.metadataCache.getFirstLinkpathDest(
+				strippedTemplateName,
+				path
+			);
+			if (!templateFile) continue;
+
+			const definition = {
+				providerTypeID: this.settings.providerTypeID,
+				entityName: fileClass.name,
+				templatePath: templateFile.path,
+				folderPath: "",
+				icon:
+					frontmatter.newEntityIcon ??
+					fileClass.options?.icon ??
+					"plus-circle",
+			};
+			definitions.push(definition);
+		}
+
+		return definitions;
+	}
+
 	/**
 	 * Generates suggestions for creating new notes based on templates for a given query.
 	 * Currently, only supports templates processed by the "templater" engine.
@@ -92,58 +150,11 @@ export class MetadataMenuProvider extends EntityProvider<MetadataMenuProviderUse
 	 * @returns An array of suggestions for entity creation.
 	 */
 	getTemplateCreationSuggestions(query: string): EntitySuggestionItem[] {
-		if (!this.mdmPlugin || !this.mdmPlugin.fieldIndex) return [];
-
-		const mdmPathsAndFileClasses: [string, MDMFileClass][] = Array.from(
-			this.mdmPlugin.fieldIndex.fileClassesPath
+		return buildEntityCreationSuggestions(
+			this.plugin,
+			this.getEntityCreationDefinitions(),
+			query
 		);
-		const fileClassTemplates: Map<string, { template: TFile, icon: string }> = new Map();
-		mdmPathsAndFileClasses.forEach(([path, fileClass]) => {			
-			const fileCache = this.plugin.app.metadataCache.getCache(path);
-			if (fileCache && fileCache.frontmatter) {
-				// TODO: make newNoteTemplate field settable in the settings
-				const newNoteTemplate = Array.isArray(fileCache.frontmatter.newNoteTemplate)
-					? fileCache.frontmatter.newNoteTemplate[0]
-					: fileCache.frontmatter.newNoteTemplate;
-				const strippedFileName = newNoteTemplate?.replace(/^\[\[|\]\]$/g, '');
-
-				// Extract newEntityIcon from frontmatter
-				const newEntityIcon = fileCache.frontmatter.newEntityIcon || fileClass.options?.icon || "plus-circle";
-
-				if (strippedFileName) {
-					const newNoteTemplateFile = this.plugin.app.metadataCache.getFirstLinkpathDest(strippedFileName, path);
-					if (newNoteTemplateFile) {
-						fileClassTemplates.set(fileClass.name, { template: newNoteTemplateFile, icon: newEntityIcon });
-					}
-				}
-			}
-		});
-
-		// TODO add support for both Template and Templater
-		return Array.from(fileClassTemplates).map(([fileClassName, { template, icon }]) => {
-			const fileClass = this.mdmPlugin?.fieldIndex?.fileClassesName.get(fileClassName);
-			if (!fileClass) {
-				throw new Error(
-					`File class not found: ${fileClassName}`
-				);
-			}
-			return {
-				suggestionText: `New ${fileClassName}: ${query}`,
-				icon: icon,
-				action: async () => {
-					await createNewNoteFromTemplate(
-						this.plugin,
-						template,
-						"", // TODO THINK ABOUT FOLDER
-						query,
-						false
-					);
-					await new Promise((resolve) => setTimeout(resolve, 20));
-					return `[[${query}]]`;
-				},
-				match: { score: -10, matches: [] } as SearchResult,
-			};
-		});
 	}
 
 	static buildSummarySetting(
@@ -158,7 +169,7 @@ export class MetadataMenuProvider extends EntityProvider<MetadataMenuProviderUse
 				"metadata-menu"
 			) !== undefined;
 		const templaterPluginOK =
-			(plugin.app as AppWithPlugins).plugins?.getPlugin("templater") !==
+			(plugin.app as AppWithPlugins).plugins?.getPlugin("templater-obsidian") !==
 			undefined;
 		const updatePluginConfiguredOKIcon = () => {
 			if (

--- a/src/cli/EntitiesCli.ts
+++ b/src/cli/EntitiesCli.ts
@@ -71,8 +71,17 @@ function buildListHandler(buildService: () => EntityCreationService): CliHandler
 					id: target.id,
 					entity: target.entityName,
 					provider: target.providerTypeID,
-					templatePath: target.templatePath,
-					folderPath: target.folderPath,
+					...(target.description
+						? { description: target.description }
+						: {}),
+					...(target.inputLabel ? { inputLabel: target.inputLabel } : {}),
+					...(target.examples ? { examples: target.examples } : {}),
+					...(target.templatePath
+						? { templatePath: target.templatePath }
+						: {}),
+					...(target.folderPath !== undefined
+						? { folderPath: target.folderPath }
+						: {}),
 					...(target.icon ? { icon: target.icon } : {}),
 				}))
 			);
@@ -83,14 +92,17 @@ function buildListHandler(buildService: () => EntityCreationService): CliHandler
 		}
 
 		return [
-			"id\tentity\tprovider\ttemplatePath\tfolderPath\ticon",
+			"id\tentity\tprovider\tdescription\tinputLabel\texamples\ttemplatePath\tfolderPath\ticon",
 			...targets.map((target) =>
 				[
 					target.id,
 					target.entityName,
 					target.providerTypeID,
-					target.templatePath,
-					target.folderPath,
+					target.description ?? "",
+					target.inputLabel ?? "",
+					target.examples?.join(", ") ?? "",
+					target.templatePath ?? "",
+					target.folderPath ?? "",
 					target.icon ?? "",
 				].join("\t")
 			),
@@ -134,8 +146,8 @@ function toCreateJson(result: EntityCreationResult): Record<string, string> {
 		name: result.name,
 		link: result.link,
 		...(result.path ? { path: result.path } : {}),
-		templatePath: result.templatePath,
-		folderPath: result.folderPath,
+		...(result.templatePath ? { templatePath: result.templatePath } : {}),
+		...(result.folderPath !== undefined ? { folderPath: result.folderPath } : {}),
 	};
 }
 

--- a/src/cli/EntitiesCli.ts
+++ b/src/cli/EntitiesCli.ts
@@ -1,0 +1,143 @@
+import type { CliData, CliFlags, CliHandler, Plugin } from "obsidian";
+import { EntityCreationService } from "../entityCreation/EntityCreationService";
+import type { EntityCreationResult } from "../entityCreation/EntityCreationService";
+import type ProviderRegistry from "../Providers/ProviderRegistry";
+
+const LIST_FLAGS: CliFlags = {
+	format: {
+		value: "<text|json>",
+		description: "Output format.",
+	},
+};
+
+const CREATE_FLAGS: CliFlags = {
+	entity: {
+		value: "<entity>",
+		description: "Creation target id or unique entity name.",
+		required: true,
+	},
+	name: {
+		value: "<name>",
+		description: "Name for the created entity note.",
+		required: true,
+	},
+	open: {
+		description: "Open the created note when set to true.",
+	},
+	format: {
+		value: "<text|json>",
+		description: "Output format.",
+	},
+};
+
+type CliCapablePlugin = Plugin &
+	Partial<Pick<Plugin, "registerCliHandler">>;
+
+/** Registers native Obsidian CLI commands for template-backed entity creation. */
+export function registerEntitiesCli(
+	plugin: Plugin,
+	providerRegistry: Pick<ProviderRegistry, "getProviders">
+): void {
+	const cliPlugin = plugin as CliCapablePlugin;
+	if (typeof cliPlugin.registerCliHandler !== "function") {
+		return;
+	}
+
+	const buildService = () =>
+		new EntityCreationService(plugin, providerRegistry.getProviders());
+
+	cliPlugin.registerCliHandler(
+		"entities",
+		"List configured entity creation targets.",
+		LIST_FLAGS,
+		buildListHandler(buildService)
+	);
+	cliPlugin.registerCliHandler(
+		"entities:create",
+		"Create an entity note from a configured target.",
+		CREATE_FLAGS,
+		buildCreateHandler(buildService)
+	);
+}
+
+function buildListHandler(buildService: () => EntityCreationService): CliHandler {
+	return (params: CliData) => {
+		const service = buildService();
+		const targets = service.listCreationTargets();
+		if (params.format === "json") {
+			return stringifyPretty(
+				targets.map((target) => ({
+					id: target.id,
+					entity: target.entityName,
+					provider: target.providerTypeID,
+					templatePath: target.templatePath,
+					folderPath: target.folderPath,
+					...(target.icon ? { icon: target.icon } : {}),
+				}))
+			);
+		}
+
+		if (targets.length === 0) {
+			return "No entity creation targets configured.";
+		}
+
+		return [
+			"id\tentity\tprovider\ttemplatePath\tfolderPath\ticon",
+			...targets.map((target) =>
+				[
+					target.id,
+					target.entityName,
+					target.providerTypeID,
+					target.templatePath,
+					target.folderPath,
+					target.icon ?? "",
+				].join("\t")
+			),
+		].join("\n");
+	};
+}
+
+function buildCreateHandler(
+	buildService: () => EntityCreationService
+): CliHandler {
+	return async (params: CliData) => {
+		const service = buildService();
+		const entity = getRequiredStringParam(params, "entity");
+		const name = getRequiredStringParam(params, "name");
+		const result = await service.create({
+			...(entity.includes(":") ? { id: entity } : { entityName: entity }),
+			name,
+			openNewNote: params.open === "true",
+		});
+
+		if (params.format === "json") {
+			return stringifyPretty(toCreateJson(result));
+		}
+
+		return result.link;
+	};
+}
+
+function getRequiredStringParam(params: CliData, key: "entity" | "name"): string {
+	const value = params[key];
+	if (value === undefined || value === "true") {
+		throw new Error(`Entities: missing required parameter "${key}".`);
+	}
+	return value;
+}
+
+function toCreateJson(result: EntityCreationResult): Record<string, string> {
+	return {
+		entity: result.entityName,
+		id: result.id,
+		name: result.name,
+		link: result.link,
+		...(result.path ? { path: result.path } : {}),
+		templatePath: result.templatePath,
+		folderPath: result.folderPath,
+	};
+}
+
+function stringifyPretty(value: unknown): string {
+	return JSON.stringify(value, null, 2);
+}

--- a/src/cli/EntitiesCli.ts
+++ b/src/cli/EntitiesCli.ts
@@ -6,14 +6,15 @@ import type ProviderRegistry from "../Providers/ProviderRegistry";
 const LIST_FLAGS: CliFlags = {
 	format: {
 		value: "<text|json>",
-		description: "Output format.",
+		description: "Output format. Use json for automation.",
 	},
 };
 
 const CREATE_FLAGS: CliFlags = {
 	entity: {
 		value: "<entity>",
-		description: "Creation target id or unique entity name.",
+		description:
+			"Target id from `obsidian entities`, such as folder:person, or a unique entity name such as person.",
 		required: true,
 	},
 	name: {
@@ -22,11 +23,11 @@ const CREATE_FLAGS: CliFlags = {
 		required: true,
 	},
 	open: {
-		description: "Open the created note when set to true.",
+		description: "Open the created note after creation.",
 	},
 	format: {
 		value: "<text|json>",
-		description: "Output format.",
+		description: "Output format. Use json for automation.",
 	},
 };
 
@@ -48,13 +49,13 @@ export function registerEntitiesCli(
 
 	cliPlugin.registerCliHandler(
 		"entities",
-		"List configured entity creation targets.",
+		"List configured Entities creation targets and stable ids for entities:create.",
 		LIST_FLAGS,
 		buildListHandler(buildService)
 	);
 	cliPlugin.registerCliHandler(
 		"entities:create",
-		"Create an entity note from a configured target.",
+		"Create an entity note using a target id or unique entity name from `obsidian entities`.",
 		CREATE_FLAGS,
 		buildCreateHandler(buildService)
 	);

--- a/src/entityCreation/EntityCreationService.ts
+++ b/src/entityCreation/EntityCreationService.ts
@@ -9,9 +9,13 @@ import { createNewNoteFromTemplate } from "src/entitiesUtilities";
 export interface EntityCreationDefinition {
 	providerTypeID: string;
 	entityName: string;
-	templatePath: string;
-	folderPath: string;
+	templatePath?: string;
+	folderPath?: string;
 	icon?: string;
+	description?: string;
+	inputLabel?: string;
+	examples?: string[];
+	create?: EntityCreationHandler;
 }
 
 /** Creation definition with the stable CLI/UI target id assigned. */
@@ -25,10 +29,28 @@ export interface EntityCreationResult {
 	entityName: string;
 	name: string;
 	link: string;
-	templatePath: string;
-	folderPath: string;
+	templatePath?: string;
+	folderPath?: string;
 	path?: string;
 }
+
+export interface EntityCreationHandlerContext {
+	plugin: Plugin;
+	target: EntityCreationTarget;
+	name: string;
+	openNewNote: boolean;
+}
+
+export interface EntityCreationHandlerResult {
+	link?: string;
+	path?: string;
+	templatePath?: string;
+	folderPath?: string;
+}
+
+export type EntityCreationHandler = (
+	context: EntityCreationHandlerContext
+) => Promise<EntityCreationHandlerResult> | EntityCreationHandlerResult;
 
 /** Request to create by exact target id or by a unique entity name. */
 export type EntityCreationRequest =
@@ -76,27 +98,26 @@ export class EntityCreationService {
 	/** Creates a note from the resolved target's template. */
 	async create(request: EntityCreationRequest): Promise<EntityCreationResult> {
 		const target = this.resolveTarget(request);
-		const createdFile = await createNewNoteFromTemplate(
+		const creationResult = await createEntityFromDefinition(
 			this.plugin,
-			target.templatePath,
-			target.folderPath,
+			target,
 			request.name,
-			request.openNewNote ?? false
+			request.openNewNote ?? false,
+			target.id
 		);
-		if (!createdFile) {
-			throw new Error(
-				`Entity creation failed for "${request.name}" using target "${target.id}".`
-			);
-		}
 
 		return {
 			id: target.id,
 			entityName: target.entityName,
 			name: request.name,
-			link: `[[${request.name}]]`,
-			templatePath: target.templatePath,
-			folderPath: target.folderPath,
-			path: createdFile.path,
+			link: creationResult.link ?? `[[${request.name}]]`,
+			...(creationResult.templatePath
+				? { templatePath: creationResult.templatePath }
+				: {}),
+			...(creationResult.folderPath !== undefined
+				? { folderPath: creationResult.folderPath }
+				: {}),
+			...(creationResult.path ? { path: creationResult.path } : {}),
 		};
 	}
 
@@ -142,4 +163,53 @@ function normalizeIDPart(value: string, fallback: string): string {
 
 function normalizeEntityName(value: string): string {
 	return value.toLowerCase();
+}
+
+export async function createEntityFromDefinition(
+	plugin: Plugin,
+	definition: EntityCreationDefinition,
+	name: string,
+	openNewNote: boolean,
+	targetId = `${definition.providerTypeID}:${definition.entityName}`
+): Promise<EntityCreationHandlerResult> {
+	const target: EntityCreationTarget = {
+		id: targetId,
+		...definition,
+	};
+
+	if (definition.create) {
+		return definition.create({
+			plugin,
+			target,
+			name,
+			openNewNote,
+		});
+	}
+
+	if (!definition.templatePath) {
+		throw new Error(
+			`Entity creation target "${targetId}" does not define a template or creation handler.`
+		);
+	}
+
+	const folderPath = definition.folderPath ?? "";
+	const createdFile = await createNewNoteFromTemplate(
+		plugin,
+		definition.templatePath,
+		folderPath,
+		name,
+		openNewNote
+	);
+	if (!createdFile) {
+		throw new Error(
+			`Entity creation failed for "${name}" using target "${targetId}".`
+		);
+	}
+
+	return {
+		link: `[[${name}]]`,
+		templatePath: definition.templatePath,
+		folderPath,
+		path: createdFile.path,
+	};
 }

--- a/src/entityCreation/EntityCreationService.ts
+++ b/src/entityCreation/EntityCreationService.ts
@@ -1,0 +1,145 @@
+import type { Plugin } from "obsidian";
+import type {
+	EntityProvider,
+	EntityProviderUserSettings,
+} from "src/Providers/EntityProvider";
+import { createNewNoteFromTemplate } from "src/entitiesUtilities";
+
+/** Provider-supplied template target for creating one entity type. */
+export interface EntityCreationDefinition {
+	providerTypeID: string;
+	entityName: string;
+	templatePath: string;
+	folderPath: string;
+	icon?: string;
+}
+
+/** Creation definition with the stable CLI/UI target id assigned. */
+export interface EntityCreationTarget extends EntityCreationDefinition {
+	id: string;
+}
+
+/** Result returned after a template-backed entity note is created. */
+export interface EntityCreationResult {
+	id: string;
+	entityName: string;
+	name: string;
+	link: string;
+	templatePath: string;
+	folderPath: string;
+	path?: string;
+}
+
+/** Request to create by exact target id or by a unique entity name. */
+export type EntityCreationRequest =
+	| {
+			id: string;
+			name: string;
+			openNewNote?: boolean;
+			entityName?: never;
+	  }
+	| {
+			entityName: string;
+			name: string;
+			openNewNote?: boolean;
+			id?: never;
+	  };
+
+/** Coordinates template-backed entity creation across enabled providers. */
+export class EntityCreationService {
+	constructor(
+		private readonly plugin: Plugin,
+		private readonly providers: EntityProvider<EntityProviderUserSettings>[]
+	) {}
+
+	/** Lists enabled provider creation targets with stable normalized ids. */
+	listCreationTargets(): EntityCreationTarget[] {
+		const assignedIds = new Map<string, number>();
+		return this.providers
+			.filter((provider) => provider.isEnabled)
+			.flatMap((provider) => provider.getEntityCreationDefinitions())
+			.map((definition) => {
+				const idBase = `${normalizeIDPart(
+					definition.providerTypeID,
+					"provider"
+				)}:${normalizeIDPart(definition.entityName, "entity")}`;
+				const count = assignedIds.get(idBase) ?? 0;
+				assignedIds.set(idBase, count + 1);
+				const id = count === 0 ? idBase : `${idBase}-${count + 1}`;
+				return {
+					id,
+					...definition,
+				};
+			});
+	}
+
+	/** Creates a note from the resolved target's template. */
+	async create(request: EntityCreationRequest): Promise<EntityCreationResult> {
+		const target = this.resolveTarget(request);
+		const createdFile = await createNewNoteFromTemplate(
+			this.plugin,
+			target.templatePath,
+			target.folderPath,
+			request.name,
+			request.openNewNote ?? false
+		);
+		if (!createdFile) {
+			throw new Error(
+				`Entity creation failed for "${request.name}" using target "${target.id}".`
+			);
+		}
+
+		return {
+			id: target.id,
+			entityName: target.entityName,
+			name: request.name,
+			link: `[[${request.name}]]`,
+			templatePath: target.templatePath,
+			folderPath: target.folderPath,
+			path: createdFile.path,
+		};
+	}
+
+	private resolveTarget(request: EntityCreationRequest): EntityCreationTarget {
+		const targets = this.listCreationTargets();
+		if (request.id !== undefined) {
+			const match = targets.find((target) => target.id === request.id);
+			if (!match) {
+				throw new Error(
+					`No entity creation target found for id "${request.id}".`
+				);
+			}
+			return match;
+		}
+
+		const requestedEntityName = normalizeEntityName(request.entityName);
+		const matches = targets.filter(
+			(target) => normalizeEntityName(target.entityName) === requestedEntityName
+		);
+		if (matches.length === 0) {
+			throw new Error(
+				`No entity creation target found for entity name "${request.entityName}".`
+			);
+		}
+		if (matches.length > 1) {
+			throw new Error(
+				`Entity name "${request.entityName}" is ambiguous. Use one of these ids: ${matches
+					.map((target) => target.id)
+					.join(", ")}.`
+			);
+		}
+		return matches[0];
+	}
+}
+
+function normalizeIDPart(value: string, fallback: string): string {
+	const normalized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+	return normalized.length > 0 ? normalized : fallback;
+}
+
+function normalizeEntityName(value: string): string {
+	return value.toLowerCase();
+}

--- a/src/entityCreation/EntityCreationSuggestions.ts
+++ b/src/entityCreation/EntityCreationSuggestions.ts
@@ -1,0 +1,28 @@
+import type { SearchResult, Plugin } from "obsidian";
+import type { EntitySuggestionItem } from "src/EntitiesSuggestor";
+import { createNewNoteFromTemplate } from "src/entitiesUtilities";
+import type { EntityCreationDefinition } from "./EntityCreationService";
+
+/** Builds the existing low-scored suggester actions from shared definitions. */
+export function buildEntityCreationSuggestions(
+	plugin: Plugin,
+	definitions: EntityCreationDefinition[],
+	query: string
+): EntitySuggestionItem[] {
+	return definitions.map((definition) => ({
+		suggestionText: `New ${definition.entityName}: ${query}`,
+		icon: definition.icon ?? "plus-circle",
+		action: async () => {
+			await createNewNoteFromTemplate(
+				plugin,
+				definition.templatePath,
+				definition.folderPath,
+				query,
+				false
+			);
+			await new Promise((resolve) => window.setTimeout(resolve, 20));
+			return `[[${query}]]`;
+		},
+		match: { score: -10, matches: [] } as SearchResult,
+	}));
+}

--- a/src/entityCreation/EntityCreationSuggestions.ts
+++ b/src/entityCreation/EntityCreationSuggestions.ts
@@ -1,7 +1,9 @@
 import type { SearchResult, Plugin } from "obsidian";
 import type { EntitySuggestionItem } from "src/EntitiesSuggestor";
-import { createNewNoteFromTemplate } from "src/entitiesUtilities";
-import type { EntityCreationDefinition } from "./EntityCreationService";
+import {
+	createEntityFromDefinition,
+	type EntityCreationDefinition,
+} from "./EntityCreationService";
 
 /** Builds the existing low-scored suggester actions from shared definitions. */
 export function buildEntityCreationSuggestions(
@@ -13,15 +15,15 @@ export function buildEntityCreationSuggestions(
 		suggestionText: `New ${definition.entityName}: ${query}`,
 		icon: definition.icon ?? "plus-circle",
 		action: async () => {
-			await createNewNoteFromTemplate(
-				plugin,
-				definition.templatePath,
-				definition.folderPath,
-				query,
-				false
-			);
+				const result = await createEntityFromDefinition(
+					plugin,
+					definition,
+					query,
+					false,
+					`${definition.providerTypeID}:${definition.entityName}`
+				);
 			await new Promise((resolve) => window.setTimeout(resolve, 20));
-			return `[[${query}]]`;
+			return result.link ?? `[[${query}]]`;
 		},
 		match: { score: -10, matches: [] } as SearchResult,
 	}));

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { DateEntityProvider } from "./Providers/DateEntityProvider";
 import { MetadataMenuProvider } from "./Providers/MetadataMenuProvider";
 import { HelperEntityProvider } from "./Providers/HelperActionsProvider";
 import { CharacterProvider } from "./Providers/CharacterProvider";
+import { registerEntitiesCli } from "./cli/EntitiesCli";
 
 export default class Entities extends Plugin {
 	settings!: EntitiesSettings;
@@ -30,7 +31,8 @@ export default class Entities extends Plugin {
 		this.suggestor = new EntitiesSuggestor(this, this.providerRegistry);
 		this.registerEditorSuggest(this.suggestor);
 		this.registerEntityProviders();
-		this.loadEntityProviders();
+		await this.loadEntityProviders();
+		registerEntitiesCli(this, this.providerRegistry);
 	}
 
 	onunload() {

--- a/tests/Providers/EntityProvider.test.ts
+++ b/tests/Providers/EntityProvider.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../src/Providers/EntityProvider";
 import { TriggerCharacter } from "../../src/entities.types";
 import { EntitySuggestionItem } from "../../src/EntitiesSuggestor";
+import { createNewNoteFromTemplate } from "../../src/entitiesUtilities";
 
 // Mock Obsidian
 jest.mock("obsidian", () => ({
@@ -92,8 +93,13 @@ const mockPlugin = {
 		},
 	},
 } as unknown as Plugin;
+const mockedCreateNewNoteFromTemplate = jest.mocked(createNewNoteFromTemplate);
 
 describe("EntityProvider base class", () => {
+	beforeEach(() => {
+		mockedCreateNewNoteFromTemplate.mockClear();
+	});
+
 	describe("constructor and settings", () => {
 		test("merges provided settings with defaults", () => {
 			const provider = new TestEntityProvider(mockPlugin, {
@@ -238,6 +244,104 @@ describe("EntityProvider base class", () => {
 			expect(results).toHaveLength(2);
 			expect(results[0].suggestionText).toBe("New Person: Test");
 			expect(results[1].suggestionText).toBe("New Project: Test");
+		});
+
+		test("exposes templater creation definitions for shared creation flows", () => {
+			const provider = new TestEntityProvider(mockPlugin, {
+				entityCreationTemplates: [
+					{
+						engine: "templater",
+						templatePath: "templates/person.md",
+						entityName: "Person",
+						folderPath: "People",
+					},
+					{
+						engine: "core",
+						templatePath: "templates/project.md",
+						entityName: "Project",
+						folderPath: "Projects",
+					},
+				],
+			});
+
+			expect(provider.getEntityCreationDefinitions()).toEqual([
+				{
+					providerTypeID: "testProvider",
+					entityName: "Person",
+					templatePath: "templates/person.md",
+					folderPath: "People",
+				},
+			]);
+		});
+
+		test("builds template creation suggestions from shared creation definitions", async () => {
+			const provider = new TestEntityProvider(mockPlugin, {
+				entityCreationTemplates: [
+					{
+						engine: "templater",
+						templatePath: "templates/person.md",
+						entityName: "Person",
+						folderPath: "People",
+					},
+				],
+			});
+			const getDefinitionsSpy = jest.spyOn(
+				provider,
+				"getEntityCreationDefinitions"
+			);
+
+			const results = provider.getTemplateCreationSuggestions("Alice");
+			const result = await results[0].action!(results[0], null);
+
+			expect(getDefinitionsSpy).toHaveBeenCalledTimes(1);
+			expect(results[0]).toMatchObject({
+				suggestionText: "New Person: Alice",
+				icon: "plus-circle",
+				match: { score: -10, matches: [] },
+			});
+			expect(result).toBe("[[Alice]]");
+			expect(mockedCreateNewNoteFromTemplate).toHaveBeenCalledWith(
+				mockPlugin,
+				"templates/person.md",
+				"People",
+				"Alice",
+				false
+			);
+		});
+
+		test("uses creation definition icon when building template creation suggestions", () => {
+			const provider = new TestEntityProvider(mockPlugin, {});
+			jest.spyOn(provider, "getEntityCreationDefinitions").mockReturnValue([
+				{
+					providerTypeID: "testProvider",
+					entityName: "Person",
+					templatePath: "templates/person.md",
+					folderPath: "People",
+					icon: "id-card",
+				},
+			]);
+
+			const results = provider.getTemplateCreationSuggestions("Alice");
+
+			expect(results).toHaveLength(1);
+			expect(results[0].icon).toBe("id-card");
+		});
+
+		test("falls back to plus-circle when a creation definition omits icon", () => {
+			const provider = new TestEntityProvider(mockPlugin, {});
+			jest.spyOn(provider, "getEntityCreationDefinitions").mockReturnValue([
+				{
+					providerTypeID: "testProvider",
+					entityName: "Person",
+					templatePath: "templates/person.md",
+					folderPath: "People",
+				},
+			]);
+
+			const results = provider.getTemplateCreationSuggestions("Alice");
+
+			expect(results).toHaveLength(1);
+			expect(results[0].icon).toBe("plus-circle");
 		});
 
 		test("template action returns link to new note", async () => {

--- a/tests/Providers/EntityProvider.test.ts
+++ b/tests/Providers/EntityProvider.test.ts
@@ -20,7 +20,7 @@ jest.mock("obsidian", () => ({
 
 // Mock entitiesUtilities
 jest.mock("../../src/entitiesUtilities", () => ({
-	createNewNoteFromTemplate: jest.fn().mockResolvedValue(undefined),
+	createNewNoteFromTemplate: jest.fn().mockResolvedValue({ path: "People/Alice.md" }),
 }));
 
 // Test implementation of EntityProvider

--- a/tests/Providers/MetadataMenuProvider.test.ts
+++ b/tests/Providers/MetadataMenuProvider.test.ts
@@ -1,0 +1,339 @@
+import { Plugin, TFile } from "obsidian";
+import { MetadataMenuProvider } from "../../src/Providers/MetadataMenuProvider";
+import { buildEntityCreationSuggestions } from "../../src/entityCreation/EntityCreationSuggestions";
+import { EntitySuggestionItem } from "../../src/EntitiesSuggestor";
+
+jest.mock("obsidian", () => {
+	class MockTFile {
+		path: string;
+
+		constructor(path: string) {
+			this.path = path;
+		}
+	}
+
+	return {
+		ExtraButtonComponent: class {},
+		Plugin: class {
+			app: unknown;
+
+			constructor(app: unknown) {
+				this.app = app;
+			}
+		},
+		SearchResult: class {},
+		Setting: class {},
+		TFile: MockTFile,
+	};
+});
+
+jest.mock("../../src/entityCreation/EntityCreationSuggestions", () => ({
+	buildEntityCreationSuggestions: jest.fn(),
+}));
+
+jest.mock("../../src/ui/validationStatus", () => ({
+	setValidationStatus: jest.fn(),
+}));
+
+interface TestFileClass {
+	name: string;
+	options?: {
+		icon?: string;
+	};
+}
+
+interface TestPluginApp {
+	metadataCache: {
+		getCache: jest.Mock;
+		getFirstLinkpathDest: jest.Mock;
+	};
+	plugins: {
+		getPlugin: jest.Mock;
+	};
+}
+
+const mockedBuildEntityCreationSuggestions = jest.mocked(
+	buildEntityCreationSuggestions
+);
+
+function createTemplate(path: string): TFile {
+	return new TFile(path);
+}
+
+function createProvider(
+	fileClassesPath?: Map<string, TestFileClass>,
+	options?: {
+		caches?: Record<string, unknown>;
+		resolvedTemplates?: Record<string, TFile | null>;
+		providerTypeID?: string;
+	}
+): {
+	provider: MetadataMenuProvider;
+	app: TestPluginApp;
+} {
+	const app: TestPluginApp = {
+		metadataCache: {
+			getCache: jest.fn((path: string) => options?.caches?.[path] ?? null),
+			getFirstLinkpathDest: jest.fn(
+				(linkpath: string) => options?.resolvedTemplates?.[linkpath] ?? null
+			),
+		},
+		plugins: {
+			getPlugin: jest.fn(() =>
+				fileClassesPath
+					? {
+							fieldIndex: {
+								fileClassesName: new Map(
+									Array.from(fileClassesPath.values()).map((fileClass) => [
+										fileClass.name,
+										fileClass,
+									])
+								),
+								fileClassesPath,
+							},
+					  }
+					: undefined
+			),
+		},
+	};
+	const provider = new MetadataMenuProvider(new Plugin(app), {
+		providerTypeID: options?.providerTypeID ?? "custom-mdm",
+	});
+
+	return { provider, app };
+}
+
+describe("MetadataMenuProvider", () => {
+	beforeEach(() => {
+		mockedBuildEntityCreationSuggestions.mockReset();
+	});
+
+	describe("getEntityCreationDefinitions", () => {
+		test("returns empty definitions when Metadata Menu is unavailable", () => {
+			const { provider } = createProvider(undefined);
+
+			expect(provider.getEntityCreationDefinitions()).toEqual([]);
+		});
+
+		test("builds definitions from Metadata Menu file classes with resolved templates", () => {
+			const personTemplate = createTemplate("Templates/Person.md");
+			const projectTemplate = createTemplate("Templates/Project.md");
+			const fileClassesPath = new Map<string, TestFileClass>([
+				["FileClasses/Person.md", { name: "Person", options: { icon: "user" } }],
+				["FileClasses/Project.md", { name: "Project" }],
+				["FileClasses/Missing Template.md", { name: "Missing Template" }],
+				["FileClasses/Missing Frontmatter.md", { name: "Missing Frontmatter" }],
+				["FileClasses/Missing Link.md", { name: "Missing Link" }],
+			]);
+			const { provider, app } = createProvider(fileClassesPath, {
+				caches: {
+					"FileClasses/Person.md": {
+						frontmatter: {
+							newNoteTemplate: "[[Templates/Person]]",
+							newEntityIcon: "id-card",
+						},
+					},
+					"FileClasses/Project.md": {
+						frontmatter: {
+							newNoteTemplate: ["Templates/Project"],
+						},
+					},
+					"FileClasses/Missing Template.md": {
+						frontmatter: {
+							newNoteTemplate: "[[Templates/Missing]]",
+						},
+					},
+					"FileClasses/Missing Frontmatter.md": {},
+					"FileClasses/Missing Link.md": {
+						frontmatter: {},
+					},
+				},
+				resolvedTemplates: {
+					"Templates/Person": personTemplate,
+					"Templates/Project": projectTemplate,
+				},
+			});
+
+			expect(provider.getEntityCreationDefinitions()).toEqual([
+				{
+					providerTypeID: "custom-mdm",
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "",
+					icon: "id-card",
+				},
+				{
+					providerTypeID: "custom-mdm",
+					entityName: "Project",
+					templatePath: "Templates/Project.md",
+					folderPath: "",
+					icon: "plus-circle",
+				},
+			]);
+			expect(app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				"Templates/Person",
+				"FileClasses/Person.md"
+			);
+			expect(app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				"Templates/Project",
+				"FileClasses/Project.md"
+			);
+		});
+
+		test("uses file class icon when frontmatter icon is missing", () => {
+			const template = createTemplate("Templates/Person.md");
+			const { provider } = createProvider(
+				new Map<string, TestFileClass>([
+					["FileClasses/Person.md", { name: "Person", options: { icon: "user" } }],
+				]),
+				{
+					caches: {
+						"FileClasses/Person.md": {
+							frontmatter: {
+								newNoteTemplate: "[[Templates/Person]]",
+							},
+						},
+					},
+					resolvedTemplates: {
+						"Templates/Person": template,
+					},
+				}
+			);
+
+			expect(provider.getEntityCreationDefinitions()[0]).toMatchObject({
+				icon: "user",
+			});
+		});
+
+		test("resolves aliased template wikilinks and plain linkpaths", () => {
+			const personTemplate = createTemplate("Templates/Person.md");
+			const projectTemplate = createTemplate("Templates/Project.md");
+			const fileClassesPath = new Map<string, TestFileClass>([
+				["FileClasses/Person.md", { name: "Person" }],
+				["FileClasses/Project.md", { name: "Project" }],
+			]);
+			const { provider, app } = createProvider(fileClassesPath, {
+				caches: {
+					"FileClasses/Person.md": {
+						frontmatter: {
+							newNoteTemplate: "[[Templates/Person|Person template]]",
+						},
+					},
+					"FileClasses/Project.md": {
+						frontmatter: {
+							newNoteTemplate: "Templates/Project|Project template",
+						},
+					},
+				},
+				resolvedTemplates: {
+					"Templates/Person": personTemplate,
+					"Templates/Project": projectTemplate,
+				},
+			});
+
+			expect(provider.getEntityCreationDefinitions()).toEqual([
+				{
+					providerTypeID: "custom-mdm",
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "",
+					icon: "plus-circle",
+				},
+				{
+					providerTypeID: "custom-mdm",
+					entityName: "Project",
+					templatePath: "Templates/Project.md",
+					folderPath: "",
+					icon: "plus-circle",
+				},
+			]);
+			expect(app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				"Templates/Person",
+				"FileClasses/Person.md"
+			);
+			expect(app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				"Templates/Project",
+				"FileClasses/Project.md"
+			);
+		});
+
+		test("omits malformed wrapped template values without resolving them", () => {
+			const personTemplate = createTemplate("Templates/Person.md");
+			const projectTemplate = createTemplate("Templates/Project.md");
+			const fileClassesPath = new Map<string, TestFileClass>([
+				["FileClasses/Person.md", { name: "Person" }],
+				["FileClasses/Project.md", { name: "Project" }],
+			]);
+			const { provider, app } = createProvider(fileClassesPath, {
+				caches: {
+					"FileClasses/Person.md": {
+						frontmatter: {
+							newNoteTemplate: "[[Templates/Person",
+						},
+					},
+					"FileClasses/Project.md": {
+						frontmatter: {
+							newNoteTemplate: "Templates/Project]]",
+						},
+					},
+				},
+				resolvedTemplates: {
+					"Templates/Person": personTemplate,
+					"Templates/Project": projectTemplate,
+				},
+			});
+
+			expect(provider.getEntityCreationDefinitions()).toEqual([]);
+			expect(app.metadataCache.getFirstLinkpathDest).not.toHaveBeenCalledWith(
+				"Templates/Person",
+				"FileClasses/Person.md"
+			);
+			expect(app.metadataCache.getFirstLinkpathDest).not.toHaveBeenCalledWith(
+				"Templates/Project",
+				"FileClasses/Project.md"
+			);
+		});
+	});
+
+	describe("getTemplateCreationSuggestions", () => {
+		test("delegates creation suggestions to shared builder", () => {
+			const suggestion = { suggestionText: "New Person: Alice" } as EntitySuggestionItem;
+			mockedBuildEntityCreationSuggestions.mockReturnValue([suggestion]);
+			const template = createTemplate("Templates/Person.md");
+			const { provider } = createProvider(
+				new Map<string, TestFileClass>([
+					["FileClasses/Person.md", { name: "Person" }],
+				]),
+				{
+					caches: {
+						"FileClasses/Person.md": {
+							frontmatter: {
+								newNoteTemplate: "[[Templates/Person]]",
+							},
+						},
+					},
+					resolvedTemplates: {
+						"Templates/Person": template,
+					},
+				}
+			);
+
+			expect(provider.getTemplateCreationSuggestions("Alice")).toEqual([
+				suggestion,
+			]);
+			expect(mockedBuildEntityCreationSuggestions).toHaveBeenCalledWith(
+				provider.plugin,
+				[
+					{
+						providerTypeID: "custom-mdm",
+						entityName: "Person",
+						templatePath: "Templates/Person.md",
+						folderPath: "",
+						icon: "plus-circle",
+					},
+				],
+				"Alice"
+			);
+		});
+	});
+});

--- a/tests/Providers/MetadataMenuProvider.test.ts
+++ b/tests/Providers/MetadataMenuProvider.test.ts
@@ -31,10 +31,6 @@ jest.mock("../../src/entityCreation/EntityCreationSuggestions", () => ({
 	buildEntityCreationSuggestions: jest.fn(),
 }));
 
-jest.mock("../../src/ui/validationStatus", () => ({
-	setValidationStatus: jest.fn(),
-}));
-
 interface TestFileClass {
 	name: string;
 	options?: {

--- a/tests/cli/EntitiesCli.test.ts
+++ b/tests/cli/EntitiesCli.test.ts
@@ -96,13 +96,14 @@ describe("registerEntitiesCli", () => {
 		expect(handlerFor(handlers, "entities").flags).toEqual({
 			format: {
 				value: "<text|json>",
-				description: "Output format.",
+				description: "Output format. Use json for automation.",
 			},
 		});
 		expect(handlerFor(handlers, "entities:create").flags).toEqual({
 			entity: {
 				value: "<entity>",
-				description: "Creation target id or unique entity name.",
+				description:
+					"Target id from `obsidian entities`, such as folder:person, or a unique entity name such as person.",
 				required: true,
 			},
 			name: {
@@ -111,11 +112,11 @@ describe("registerEntitiesCli", () => {
 				required: true,
 			},
 			open: {
-				description: "Open the created note when set to true.",
+				description: "Open the created note after creation.",
 			},
 			format: {
 				value: "<text|json>",
-				description: "Output format.",
+				description: "Output format. Use json for automation.",
 			},
 		});
 	});

--- a/tests/cli/EntitiesCli.test.ts
+++ b/tests/cli/EntitiesCli.test.ts
@@ -1,0 +1,357 @@
+import type { CliFlags, CliHandler, Plugin } from "obsidian";
+import { registerEntitiesCli } from "../../src/cli/EntitiesCli";
+import type {
+	EntityProvider,
+	EntityProviderUserSettings,
+} from "../../src/Providers/EntityProvider";
+import type { EntityCreationDefinition } from "../../src/entityCreation/EntityCreationService";
+import { createNewNoteFromTemplate } from "../../src/entitiesUtilities";
+
+jest.mock("../../src/entitiesUtilities", () => ({
+	createNewNoteFromTemplate: jest.fn(),
+}));
+
+interface RegisteredCliHandler {
+	command: string;
+	description: string;
+	flags: CliFlags | null;
+	handler: CliHandler;
+}
+
+const mockedCreateNewNoteFromTemplate = jest.mocked(createNewNoteFromTemplate);
+
+function provider(
+	providerTypeID: string,
+	definitions: Omit<EntityCreationDefinition, "providerTypeID">[],
+	enabled = true
+): EntityProvider<EntityProviderUserSettings> {
+	return {
+		isEnabled: enabled,
+		getEntityCreationDefinitions: () =>
+			definitions.map((definition) => ({
+				...definition,
+				providerTypeID,
+			})),
+	} as EntityProvider<EntityProviderUserSettings>;
+}
+
+function registerWithProviders(
+	providers: EntityProvider<EntityProviderUserSettings>[]
+): RegisteredCliHandler[] {
+	const handlers: RegisteredCliHandler[] = [];
+	const plugin = {
+		registerCliHandler: jest.fn(
+			(
+				command: string,
+				description: string,
+				flags: CliFlags | null,
+				handler: CliHandler
+			) => {
+				handlers.push({ command, description, flags, handler });
+			}
+		),
+	} as unknown as Plugin;
+	const providerRegistry = {
+		getProviders: jest.fn(() => providers),
+	};
+
+	registerEntitiesCli(plugin, providerRegistry);
+
+	return handlers;
+}
+
+function handlerFor(
+	handlers: RegisteredCliHandler[],
+	command: string
+): RegisteredCliHandler {
+	const handler = handlers.find((item) => item.command === command);
+	if (!handler) {
+		throw new Error(`Missing handler for ${command}`);
+	}
+	return handler;
+}
+
+describe("registerEntitiesCli", () => {
+	beforeEach(() => {
+		mockedCreateNewNoteFromTemplate.mockReset();
+	});
+
+	test("does not throw or load providers when native CLI registration is unavailable", () => {
+		const plugin = {} as Plugin;
+		const providerRegistry = {
+			getProviders: jest.fn(),
+		};
+
+		expect(() => registerEntitiesCli(plugin, providerRegistry)).not.toThrow();
+		expect(providerRegistry.getProviders).not.toHaveBeenCalled();
+	});
+
+	test("registers list and create CLI commands", () => {
+		const handlers = registerWithProviders([]);
+
+		expect(handlers.map((handler) => handler.command)).toEqual([
+			"entities",
+			"entities:create",
+		]);
+		expect(handlerFor(handlers, "entities").flags).toEqual({
+			format: {
+				value: "<text|json>",
+				description: "Output format.",
+			},
+		});
+		expect(handlerFor(handlers, "entities:create").flags).toEqual({
+			entity: {
+				value: "<entity>",
+				description: "Creation target id or unique entity name.",
+				required: true,
+			},
+			name: {
+				value: "<name>",
+				description: "Name for the created entity note.",
+				required: true,
+			},
+			open: {
+				description: "Open the created note when set to true.",
+			},
+			format: {
+				value: "<text|json>",
+				description: "Output format.",
+			},
+		});
+	});
+
+	test("lists configured creation targets as deterministic text", async () => {
+		const handlers = registerWithProviders([
+			provider("People Provider", [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+					icon: "user",
+				},
+				{
+					entityName: "Project",
+					templatePath: "Templates/Project.md",
+					folderPath: "Projects",
+				},
+			]),
+		]);
+
+		await expect(
+			Promise.resolve(handlerFor(handlers, "entities").handler({}))
+		).resolves.toBe(
+			[
+				"id\tentity\tprovider\ttemplatePath\tfolderPath\ticon",
+				"people-provider:person\tPerson\tPeople Provider\tTemplates/Person.md\tPeople\tuser",
+				"people-provider:project\tProject\tPeople Provider\tTemplates/Project.md\tProjects\t",
+			].join("\n")
+		);
+	});
+
+	test("returns an empty-target message for text list output", async () => {
+		const handlers = registerWithProviders([]);
+
+		await expect(
+			Promise.resolve(handlerFor(handlers, "entities").handler({}))
+		).resolves.toBe(
+			"No entity creation targets configured."
+		);
+	});
+
+	test("lists configured creation targets as pretty JSON", async () => {
+		const handlers = registerWithProviders([
+			provider("People Provider", [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+					icon: "user",
+				},
+				{
+					entityName: "Project",
+					templatePath: "Templates/Project.md",
+					folderPath: "Projects",
+				},
+			]),
+		]);
+
+		await expect(
+			Promise.resolve(
+				handlerFor(handlers, "entities").handler({ format: "json" })
+			)
+		).resolves.toBe(
+			JSON.stringify(
+				[
+					{
+						id: "people-provider:person",
+						entity: "Person",
+						provider: "People Provider",
+						templatePath: "Templates/Person.md",
+						folderPath: "People",
+						icon: "user",
+					},
+					{
+						id: "people-provider:project",
+						entity: "Project",
+						provider: "People Provider",
+						templatePath: "Templates/Project.md",
+						folderPath: "Projects",
+					},
+				],
+				null,
+				2
+			)
+		);
+	});
+
+	test("list handler resolves providers from the registry for each invocation", async () => {
+		let providers = [
+			provider("People Provider", [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		];
+		const handlers: RegisteredCliHandler[] = [];
+		const plugin = {
+			registerCliHandler: jest.fn(
+				(
+					command: string,
+					description: string,
+					flags: CliFlags | null,
+					handler: CliHandler
+				) => {
+					handlers.push({ command, description, flags, handler });
+				}
+			),
+		} as unknown as Plugin;
+		const providerRegistry = {
+			getProviders: jest.fn(() => providers),
+		};
+		registerEntitiesCli(plugin, providerRegistry);
+		providers = [
+			provider("Projects Provider", [
+				{
+					entityName: "Project",
+					templatePath: "Templates/Project.md",
+					folderPath: "Projects",
+				},
+			]),
+		];
+
+		await expect(
+			Promise.resolve(
+				handlerFor(handlers, "entities").handler({ format: "json" })
+			)
+		).resolves.toBe(
+			JSON.stringify(
+				[
+					{
+						id: "projects-provider:project",
+						entity: "Project",
+						provider: "Projects Provider",
+						templatePath: "Templates/Project.md",
+						folderPath: "Projects",
+					},
+				],
+				null,
+				2
+			)
+		);
+		expect(providerRegistry.getProviders).toHaveBeenCalledTimes(1);
+	});
+
+	test("creates by exact id and returns the created link as text", async () => {
+		mockedCreateNewNoteFromTemplate.mockResolvedValue({
+			path: "People/Alice.md",
+		});
+		const handlers = registerWithProviders([
+			provider("People Provider", [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			handlerFor(handlers, "entities:create").handler({
+				entity: "people-provider:person",
+				name: "Alice",
+				open: "true",
+			})
+		).resolves.toBe("[[Alice]]");
+		expect(mockedCreateNewNoteFromTemplate).toHaveBeenCalledWith(
+			expect.anything(),
+			"Templates/Person.md",
+			"People",
+			"Alice",
+			true
+		);
+	});
+
+	test("creates by unique entity name and returns pretty JSON", async () => {
+		mockedCreateNewNoteFromTemplate.mockResolvedValue({
+			path: "Projects/Launch.md",
+		});
+		const handlers = registerWithProviders([
+			provider("Projects Provider", [
+				{
+					entityName: "Project",
+					templatePath: "Templates/Project.md",
+					folderPath: "Projects",
+				},
+			]),
+		]);
+
+		await expect(
+			handlerFor(handlers, "entities:create").handler({
+				entity: "project",
+				name: "Launch",
+				format: "json",
+			})
+		).resolves.toBe(
+			JSON.stringify(
+				{
+					entity: "Project",
+					id: "projects-provider:project",
+					name: "Launch",
+					link: "[[Launch]]",
+					path: "Projects/Launch.md",
+					templatePath: "Templates/Project.md",
+					folderPath: "Projects",
+				},
+				null,
+				2
+			)
+		);
+		expect(mockedCreateNewNoteFromTemplate).toHaveBeenCalledWith(
+			expect.anything(),
+			"Templates/Project.md",
+			"Projects",
+			"Launch",
+			false
+		);
+	});
+
+	test("throws clear errors when create required parameters are missing", async () => {
+		const handlers = registerWithProviders([]);
+		const createHandler = handlerFor(handlers, "entities:create").handler;
+
+		await expect(createHandler({ name: "Alice" })).rejects.toThrow(
+			'Entities: missing required parameter "entity".'
+		);
+		await expect(createHandler({ entity: "person" })).rejects.toThrow(
+			'Entities: missing required parameter "name".'
+		);
+		await expect(createHandler({ entity: "true", name: "Alice" })).rejects.toThrow(
+			'Entities: missing required parameter "entity".'
+		);
+		await expect(createHandler({ entity: "person", name: "true" })).rejects.toThrow(
+			'Entities: missing required parameter "name".'
+		);
+	});
+});

--- a/tests/cli/EntitiesCli.test.ts
+++ b/tests/cli/EntitiesCli.test.ts
@@ -129,6 +129,9 @@ describe("registerEntitiesCli", () => {
 					templatePath: "Templates/Person.md",
 					folderPath: "People",
 					icon: "user",
+					description: "Create a person note.",
+					inputLabel: "Person name",
+					examples: ["Ada Lovelace"],
 				},
 				{
 					entityName: "Project",
@@ -142,9 +145,9 @@ describe("registerEntitiesCli", () => {
 			Promise.resolve(handlerFor(handlers, "entities").handler({}))
 		).resolves.toBe(
 			[
-				"id\tentity\tprovider\ttemplatePath\tfolderPath\ticon",
-				"people-provider:person\tPerson\tPeople Provider\tTemplates/Person.md\tPeople\tuser",
-				"people-provider:project\tProject\tPeople Provider\tTemplates/Project.md\tProjects\t",
+				"id\tentity\tprovider\tdescription\tinputLabel\texamples\ttemplatePath\tfolderPath\ticon",
+				"people-provider:person\tPerson\tPeople Provider\tCreate a person note.\tPerson name\tAda Lovelace\tTemplates/Person.md\tPeople\tuser",
+				"people-provider:project\tProject\tPeople Provider\t\t\t\tTemplates/Project.md\tProjects\t",
 			].join("\n")
 		);
 	});
@@ -167,6 +170,9 @@ describe("registerEntitiesCli", () => {
 					templatePath: "Templates/Person.md",
 					folderPath: "People",
 					icon: "user",
+					description: "Create a person note.",
+					inputLabel: "Person name",
+					examples: ["Ada Lovelace"],
 				},
 				{
 					entityName: "Project",
@@ -187,6 +193,9 @@ describe("registerEntitiesCli", () => {
 						id: "people-provider:person",
 						entity: "Person",
 						provider: "People Provider",
+						description: "Create a person note.",
+						inputLabel: "Person name",
+						examples: ["Ada Lovelace"],
 						templatePath: "Templates/Person.md",
 						folderPath: "People",
 						icon: "user",

--- a/tests/entityCreation/EntityCreationService.test.ts
+++ b/tests/entityCreation/EntityCreationService.test.ts
@@ -1,0 +1,396 @@
+import { Plugin, TFile } from "obsidian";
+import {
+	EntityCreationDefinition,
+	EntityCreationService,
+} from "../../src/entityCreation/EntityCreationService";
+import {
+	EntityProvider,
+	EntityProviderUserSettings,
+} from "../../src/Providers/EntityProvider";
+import { TriggerCharacter } from "../../src/entities.types";
+import { EntitySuggestionItem } from "../../src/EntitiesSuggestor";
+import { createNewNoteFromTemplate } from "../../src/entitiesUtilities";
+
+jest.mock("obsidian", () => ({
+	Plugin: class {
+		app: unknown;
+		constructor(app: unknown) {
+			this.app = app;
+		}
+	},
+	TFile: class {
+		path: string;
+		constructor(path: string) {
+			this.path = path;
+		}
+	},
+}));
+
+jest.mock("../../src/entitiesUtilities", () => ({
+	createNewNoteFromTemplate: jest.fn(),
+}));
+
+interface TestProviderSettings extends EntityProviderUserSettings {
+	providerTypeID: string;
+}
+
+class CreationProvider extends EntityProvider<TestProviderSettings> {
+	private readonly definitions: EntityCreationDefinition[];
+
+	constructor(
+		plugin: Plugin,
+		settings: Partial<TestProviderSettings>,
+		definitions: EntityCreationDefinition[]
+	) {
+		super(plugin, settings);
+		this.definitions = definitions;
+	}
+
+	getDefaultSettings(): TestProviderSettings {
+		return {
+			providerTypeID: "test-provider",
+			enabled: true,
+			icon: "test-icon",
+		};
+	}
+
+	getEntityList(_query: string, _trigger: TriggerCharacter): EntitySuggestionItem[] {
+		return [];
+	}
+
+	getEntityCreationDefinitions(): EntityCreationDefinition[] {
+		return this.definitions;
+	}
+}
+
+const plugin = {} as Plugin;
+const mockedCreateNewNoteFromTemplate = jest.mocked(createNewNoteFromTemplate);
+
+function provider(
+	providerTypeID: string,
+	enabled: boolean,
+	definitions: Omit<EntityCreationDefinition, "providerTypeID">[]
+): CreationProvider {
+	return new CreationProvider(
+		plugin,
+		{
+			providerTypeID,
+			enabled,
+			icon: "test-icon",
+		},
+		definitions.map((definition) => ({
+			...definition,
+			providerTypeID,
+		}))
+	);
+}
+
+describe("EntityCreationService", () => {
+	beforeEach(() => {
+		mockedCreateNewNoteFromTemplate.mockReset();
+	});
+
+	test("lists creation targets from enabled providers with stable normalized ids", () => {
+		const service = new EntityCreationService(plugin, [
+			provider("Folder Provider", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+				{
+					entityName: "Movie Character",
+					templatePath: "Templates/Character.md",
+					folderPath: "",
+				},
+			]),
+			provider("Disabled Provider", false, [
+				{
+					entityName: "Should Not Appear",
+					templatePath: "Templates/Hidden.md",
+					folderPath: "Hidden",
+				},
+			]),
+		]);
+
+		expect(service.listCreationTargets()).toEqual([
+			{
+				id: "folder-provider:person",
+				providerTypeID: "Folder Provider",
+				entityName: "Person",
+				templatePath: "Templates/Person.md",
+				folderPath: "People",
+			},
+			{
+				id: "folder-provider:movie-character",
+				providerTypeID: "Folder Provider",
+				entityName: "Movie Character",
+				templatePath: "Templates/Character.md",
+				folderPath: "",
+			},
+		]);
+	});
+
+	test("keeps distinct normalized ids without suffixes", () => {
+		const service = new EntityCreationService(plugin, [
+			provider("Characters", true, [
+				{
+					entityName: "NPC",
+					templatePath: "Templates/NPC.md",
+					folderPath: "Characters",
+				},
+				{
+					entityName: "N.P.C.",
+					templatePath: "Templates/NPC Alternate.md",
+					folderPath: "Characters",
+				},
+			]),
+		]);
+
+		expect(service.listCreationTargets().map((target) => target.id)).toEqual([
+			"characters:npc",
+			"characters:n-p-c",
+		]);
+	});
+
+	test("adds numeric suffixes when duplicate ids remain after normalization", () => {
+		const service = new EntityCreationService(plugin, [
+			provider("Characters", true, [
+				{
+					entityName: "NPC",
+					templatePath: "Templates/NPC.md",
+					folderPath: "Characters",
+				},
+				{
+					entityName: "NPC!",
+					templatePath: "Templates/NPC Bang.md",
+					folderPath: "Characters",
+				},
+			]),
+		]);
+
+		expect(service.listCreationTargets().map((target) => target.id)).toEqual([
+			"characters:npc",
+			"characters:npc-2",
+		]);
+	});
+
+	test("uses fallback id parts when provider or entity names normalize empty", () => {
+		const service = new EntityCreationService(plugin, [
+			provider("!!!", true, [
+				{
+					entityName: "???",
+					templatePath: "Templates/Symbol.md",
+					folderPath: "Symbols",
+				},
+				{
+					entityName: "...",
+					templatePath: "Templates/Symbol Alternate.md",
+					folderPath: "Symbols",
+				},
+			]),
+		]);
+
+		expect(service.listCreationTargets().map((target) => target.id)).toEqual([
+			"provider:entity",
+			"provider:entity-2",
+		]);
+	});
+
+	test("creates by exact id and returns creation result details", async () => {
+		const createdFile = new TFile("People/Alice.md");
+		mockedCreateNewNoteFromTemplate.mockResolvedValue(createdFile);
+		const service = new EntityCreationService(plugin, [
+			provider("Folder Provider", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				id: "folder-provider:person",
+				name: "Alice",
+				openNewNote: true,
+			})
+		).resolves.toEqual({
+			id: "folder-provider:person",
+			entityName: "Person",
+			name: "Alice",
+			link: "[[Alice]]",
+			templatePath: "Templates/Person.md",
+			folderPath: "People",
+			path: "People/Alice.md",
+		});
+		expect(mockedCreateNewNoteFromTemplate).toHaveBeenCalledWith(
+			plugin,
+			"Templates/Person.md",
+			"People",
+			"Alice",
+			true
+		);
+	});
+
+	test("creates by unique entity name with openNewNote defaulting to false", async () => {
+		const createdFile = new TFile("People/Bob.md");
+		mockedCreateNewNoteFromTemplate.mockResolvedValue(createdFile);
+		const service = new EntityCreationService(plugin, [
+			provider("People", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "Person",
+				name: "Bob",
+			})
+		).resolves.toEqual({
+			id: "people:person",
+			entityName: "Person",
+			name: "Bob",
+			link: "[[Bob]]",
+			templatePath: "Templates/Person.md",
+			folderPath: "People",
+			path: "People/Bob.md",
+		});
+		expect(mockedCreateNewNoteFromTemplate).toHaveBeenCalledWith(
+			plugin,
+			"Templates/Person.md",
+			"People",
+			"Bob",
+			false
+		);
+	});
+
+	test("creates by unique entity name case-insensitively", async () => {
+		const createdFile = new TFile("People/Bob.md");
+		mockedCreateNewNoteFromTemplate.mockResolvedValue(createdFile);
+		const service = new EntityCreationService(plugin, [
+			provider("People", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "person",
+				name: "Bob",
+			})
+		).resolves.toEqual({
+			id: "people:person",
+			entityName: "Person",
+			name: "Bob",
+			link: "[[Bob]]",
+			templatePath: "Templates/Person.md",
+			folderPath: "People",
+			path: "People/Bob.md",
+		});
+		expect(mockedCreateNewNoteFromTemplate).toHaveBeenCalledWith(
+			plugin,
+			"Templates/Person.md",
+			"People",
+			"Bob",
+			false
+		);
+	});
+
+	test("throws a clear error when template creation returns no file", async () => {
+		mockedCreateNewNoteFromTemplate.mockResolvedValue(undefined);
+		const service = new EntityCreationService(plugin, [
+			provider("People", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "Person",
+				name: "Bob",
+			})
+		).rejects.toThrow(
+			'Entity creation failed for "Bob" using target "people:person".'
+		);
+	});
+
+	test("throws a clear error when no id matches", async () => {
+		const service = new EntityCreationService(plugin, [
+			provider("People", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				id: "people:project",
+				name: "Launch",
+			})
+		).rejects.toThrow('No entity creation target found for id "people:project".');
+	});
+
+	test("throws a clear error when no entity name matches", async () => {
+		const service = new EntityCreationService(plugin, [
+			provider("People", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "Project",
+				name: "Launch",
+			})
+		).rejects.toThrow('No entity creation target found for entity name "Project".');
+	});
+
+	test("throws a clear error for ambiguous entity names", async () => {
+		const service = new EntityCreationService(plugin, [
+			provider("People", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Person.md",
+					folderPath: "People",
+				},
+			]),
+			provider("Characters", true, [
+				{
+					entityName: "Person",
+					templatePath: "Templates/Character.md",
+					folderPath: "Characters",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "Person",
+				name: "Alice",
+			})
+		).rejects.toThrow(
+			'Entity name "Person" is ambiguous. Use one of these ids: people:person, characters:person.'
+		);
+	});
+});

--- a/tests/entityCreation/EntityCreationService.test.ts
+++ b/tests/entityCreation/EntityCreationService.test.ts
@@ -97,6 +97,9 @@ describe("EntityCreationService", () => {
 					entityName: "Person",
 					templatePath: "Templates/Person.md",
 					folderPath: "People",
+					description: "Create a person note.",
+					inputLabel: "Person name",
+					examples: ["Ada Lovelace", "Grace Hopper"],
 				},
 				{
 					entityName: "Movie Character",
@@ -120,6 +123,9 @@ describe("EntityCreationService", () => {
 				entityName: "Person",
 				templatePath: "Templates/Person.md",
 				folderPath: "People",
+				description: "Create a person note.",
+				inputLabel: "Person name",
+				examples: ["Ada Lovelace", "Grace Hopper"],
 			},
 			{
 				id: "folder-provider:movie-character",
@@ -267,6 +273,70 @@ describe("EntityCreationService", () => {
 			"People",
 			"Bob",
 			false
+		);
+	});
+
+	test("creates through a provider-specific creation handler", async () => {
+		const create = jest.fn().mockResolvedValue({
+			link: "[[Weeks/2026-W01|2026-W01]]",
+			path: "Weeks/2026-W01.md",
+			folderPath: "Weeks",
+		});
+		const service = new EntityCreationService(plugin, [
+			provider("Dates", true, [
+				{
+					entityName: "Week",
+					description: "Create a weekly note from an ISO week.",
+					inputLabel: "ISO week or natural week phrase",
+					examples: ["this week", "next week", "2026-W01"],
+					icon: "calendar-range",
+					create,
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "week",
+				name: "2026-W01",
+				openNewNote: true,
+			})
+		).resolves.toEqual({
+			id: "dates:week",
+			entityName: "Week",
+			name: "2026-W01",
+			link: "[[Weeks/2026-W01|2026-W01]]",
+			folderPath: "Weeks",
+			path: "Weeks/2026-W01.md",
+		});
+		expect(create).toHaveBeenCalledWith({
+			plugin,
+			target: expect.objectContaining({
+				id: "dates:week",
+				entityName: "Week",
+			}),
+			name: "2026-W01",
+			openNewNote: true,
+		});
+		expect(mockedCreateNewNoteFromTemplate).not.toHaveBeenCalled();
+	});
+
+	test("throws a clear error when a target has no template or custom creation handler", async () => {
+		const service = new EntityCreationService(plugin, [
+			provider("Custom", true, [
+				{
+					entityName: "Broken",
+				},
+			]),
+		]);
+
+		await expect(
+			service.create({
+				entityName: "Broken",
+				name: "Anything",
+			})
+		).rejects.toThrow(
+			'Entity creation target "custom:broken" does not define a template or creation handler.'
 		);
 	});
 


### PR DESCRIPTION
## Summary

Adds native Obsidian CLI support for Entities so agents and users can discover configured creation targets and create notes through the same creation flow used by the suggester.

## What changed

- Added a shared `EntityCreationService` for listing creation targets, resolving target ids or unique entity names, and creating notes.
- Added a provider extension point for creation targets:
  - template-backed targets can use `templatePath` / `folderPath`
  - provider-defined targets can supply their own `create()` handler
  - targets can expose `description`, `inputLabel`, and `examples` for CLI/agent discoverability
- Added a UI suggestion adapter so `New <Entity>: <query>` suggestions and CLI creation share the same target model.
- Exposed Metadata Menu file-class creation templates as shared creation targets, including icon preservation and Obsidian wikilink alias parsing.
- Registered native CLI commands when `registerCliHandler` is available:
  - `obsidian entities`
  - `obsidian entities format=json`
  - `obsidian entities:create entity=person name="Ada Lovelace"`
  - `obsidian entities:create entity=folder:person name="Ada Lovelace" open format=json`
- Made CLI handlers resolve providers lazily on each invocation so settings changes are reflected without plugin reload.
- Updated README and architecture docs, including `obsidian help entities`, `obsidian help entities:create`, and JSON target discovery guidance.

## CLI discoverability

The registered CLI command descriptions and flag descriptions are designed to be useful from Obsidian CLI help output. An agent can run:

```bash
obsidian help entities
obsidian help entities:create
obsidian entities format=json
```

The JSON target list includes provider-supplied `description`, `inputLabel`, and `examples` when available. Providers can use those fields to document valid input formats before an agent calls `entities:create`.

## Verification

- `npm test` (12 suites, 162 tests)
- `npm run build`

Notes: this PR is rebased onto `origin/master`; that base does not define an `npm run lint` script. The test run still emits existing `ts-jest` `esModuleInterop`, Node `punycode`, and expected ProviderRegistry console-error output from the existing suite.