### PR TITLE
fix: resolve high severity npm audit findings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,6 +50,7 @@ export default tseslint.config(
 	{
 		ignores: [
 			"node_modules/",
+			".agents/",
 			"main.js",
 			"dist/",
 			"coverage/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 				"jest-environment-jsdom": "^29.7.0",
 				"moment": "^2.30.1",
 				"obsidian": "^1.7.2",
-				"obsidian-dataview": "^0.5.64",
 				"rollup": "^4.14.2",
 				"ts-jest": "^29.1.2",
 				"ts-node": "^10.9.2",
@@ -550,20 +549,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@codemirror/language": {
-			"version": "6.11.2",
-			"resolved": "git+ssh://git@github.com/lishid/cm-language.git#2d416d7835867d1b1e8d0e726b147fc1135c9f92",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.23.0",
-				"@lezer/common": "^1.1.0",
-				"@lezer/highlight": "^1.0.0",
-				"@lezer/lr": "^1.0.0",
-				"style-mod": "^4.0.0"
-			}
 		},
 		"node_modules/@codemirror/state": {
 			"version": "6.5.0",
@@ -1696,33 +1681,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@lezer/common": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-			"integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@lezer/highlight": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
-			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@lezer/common": "^1.3.0"
-			}
-		},
-		"node_modules/@lezer/lr": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@lezer/common": "^1.0.0"
-			}
-		},
 		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
@@ -2176,9 +2134,9 @@
 			}
 		},
 		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+			"integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3201,9 +3159,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3864,13 +3822,6 @@
 			"funding": {
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
 			}
-		},
-		"node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/emojilib": {
 			"version": "3.0.12",
@@ -5308,9 +5259,9 @@
 			"license": "ISC"
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5504,13 +5455,6 @@
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/immediate": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
@@ -7011,32 +6955,12 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/lie": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-			"integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"immediate": "~3.0.5"
-			}
-		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/localforage": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-			"integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"lie": "3.1.1"
-			}
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -7089,16 +7013,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/luxon": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/make-dir": {
@@ -7469,66 +7383,6 @@
 				"@codemirror/view": "6.38.6"
 			}
 		},
-		"node_modules/obsidian-calendar-ui": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.12.tgz",
-			"integrity": "sha512-hdoRqCPnukfRgCARgArXaqMQZ+Iai0eY7f0ZsFHHfywpv4gKg3Tx5p47UsLvRO5DD+4knlbrL7Gel57MkfcLTw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"obsidian-daily-notes-interface": "0.8.4",
-				"svelte": "3.35.0",
-				"tslib": "2.1.0"
-			}
-		},
-		"node_modules/obsidian-calendar-ui/node_modules/tslib": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/obsidian-daily-notes-interface": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.8.4.tgz",
-			"integrity": "sha512-REKQtAuIOKDbvNH/th1C1gWmJWCP5tRn9T/mfZGZt4Zncgko7McXK0aSKFtEInipvgbZJ2nScivvyLdiWluSMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"obsidian": "github:obsidianmd/obsidian-api#master",
-				"tslib": "2.1.0"
-			},
-			"bin": {
-				"obsidian-daily-notes-interface": "dist/main.js"
-			}
-		},
-		"node_modules/obsidian-daily-notes-interface/node_modules/tslib": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/obsidian-dataview": {
-			"version": "0.5.68",
-			"resolved": "https://registry.npmjs.org/obsidian-dataview/-/obsidian-dataview-0.5.68.tgz",
-			"integrity": "sha512-eoYVxqgeAUM64fV6/YXWuXvmm9DaVoR1h/O+vBIHS0yQ+n9x5MaVndD3WjcVWuaJmrMM9iwvutkbZ0aCWpLmHw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/language": "git+https://github.com/lishid/cm-language.git",
-				"@codemirror/state": "^6.0.1",
-				"@codemirror/view": "^6.0.1",
-				"emoji-regex": "^10.0.0",
-				"localforage": "^1.10.0",
-				"luxon": "^3.2.0",
-				"obsidian-calendar-ui": "^0.3.12",
-				"papaparse": "^5.3.1",
-				"parsimmon": "^1.18.0",
-				"preact": "^10.6.5",
-				"remove-markdown": "^0.5.5"
-			}
-		},
 		"node_modules/obsidian/node_modules/moment": {
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -7643,13 +7497,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/papaparse": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-			"integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7694,13 +7541,6 @@
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
-		},
-		"node_modules/parsimmon": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
-			"integrity": "sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -7747,9 +7587,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7846,17 +7686,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/preact": {
-			"version": "10.28.4",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
-			"integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -8037,13 +7866,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/remove-markdown": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.5.tgz",
-			"integrity": "sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -8768,16 +8590,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/svelte": {
-			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
-			"integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/symbol-tree": {
@@ -9651,9 +9463,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"jest-environment-jsdom": "^29.7.0",
 		"moment": "^2.30.1",
 		"obsidian": "^1.7.2",
-		"obsidian-dataview": "^0.5.64",
 		"rollup": "^4.14.2",
 		"ts-jest": "^29.1.2",
 		"ts-node": "^10.9.2",

--- a/src/Providers/DataviewEntityProvider.ts
+++ b/src/Providers/DataviewEntityProvider.ts
@@ -8,17 +8,32 @@ import {
 	TFile,
 	TFolder,
 } from "obsidian";
-import { getAPI, DataviewApi } from "obsidian-dataview";
 import { EntitySuggestionItem } from "src/EntitiesSuggestor";
 import { EntityProvider, EntityProviderUserSettings } from "./EntityProvider";
 import { TextInputSuggest, TextInputSuggestOptions } from "src/ui/suggest";
-import { EntityFilter } from "src/entities.types";
+import { AppWithPlugins, EntityFilter } from "src/entities.types";
 import { buildIconPickerSetting, buildTemplateCreationSetting } from "src/ui/providerSettingsComponents";
 import { applyFiltersToQueryResults } from "./EntityFilters";
 import { FrontmatterKeySuggest } from "src/ui/FrontmatterKeySuggest";
 import { setValidationStatus } from "src/ui/validationStatus";
 
 const dataviewProviderTypeID = "dataview";
+
+interface DataviewPage {
+	file: {
+		path: string;
+		name: string;
+		aliases: string[];
+	};
+}
+
+interface DataviewApi {
+	pages(query: string): DataviewPage[];
+}
+
+interface DataviewPlugin {
+	api?: DataviewApi;
+}
 
 export interface DataviewProviderUserSettings
 	extends EntityProviderUserSettings {
@@ -118,7 +133,7 @@ export class DataviewEntityProvider extends EntityProvider<DataviewProviderUserS
 		const queryIsOK = (
 			query: string
 		): "ok" | "error" | "empty" | "dv not found" => {
-			const dv: DataviewApi | undefined = getAPI(plugin.app);
+			const dv = DataviewEntityProvider.getDataviewApi(plugin.app);
 			if (!dv) {
 				return "dv not found";
 			}
@@ -364,7 +379,7 @@ export class DataviewEntityProvider extends EntityProvider<DataviewProviderUserS
 
 			const attemptFetching = () => {
 				attempts++;
-				const dv: DataviewApi | undefined = getAPI(app);
+				const dv = DataviewEntityProvider.getDataviewApi(app);
 				if (dv || attempts >= maxAttempts) {
 					resolve(dv);
 				} else {
@@ -375,6 +390,20 @@ export class DataviewEntityProvider extends EntityProvider<DataviewProviderUserS
 			attemptFetching();
 		});
 	};
+
+	private static getDataviewApi(app: App): DataviewApi | undefined {
+		const appWithPlugins = app as AppWithPlugins;
+		const dataviewPlugin =
+			(appWithPlugins.plugins?.getPlugin?.("dataview") as
+				| DataviewPlugin
+				| undefined) ??
+			(appWithPlugins.plugins?.plugins?.dataview as
+				| DataviewPlugin
+				| undefined);
+		const api = dataviewPlugin?.api;
+
+		return api && typeof api.pages === "function" ? api : undefined;
+	}
 }
 
 export class DataviewSourceSuggest extends TextInputSuggest<string> {

--- a/src/entities.types.ts
+++ b/src/entities.types.ts
@@ -66,6 +66,7 @@ export interface AppWithPlugins extends App {
 	plugins:
 		| undefined
 		| {
-				getPlugin(pluginName: string): Plugin | undefined;
-          };
+					getPlugin(pluginName: string): Plugin | undefined;
+					plugins?: Record<string, unknown>;
+	          };
 }


### PR DESCRIPTION
## Summary
- remove the direct obsidian-dataview package dependency and access Dataview through the runtime Obsidian plugin API
- update safe transitive dependency patches from npm audit fix
- ignore the project-local .agents tooling directory in ESLint

## Validation
- npm audit --audit-level=high
- npm test -- --runInBand
- npm run build
- npm run lint